### PR TITLE
Remove hardcoded bound of 3 cyclic colors for bar graph

### DIFF
--- a/src/charts/Bar.js
+++ b/src/charts/Bar.js
@@ -80,7 +80,7 @@ export default class BarChart extends  React.Component
         var textStyle = fontAdapt(options.axisX.label);
 
         var lines = chart.curves.map(function (c, i) {
-            var color = this.color(i % 3);
+            var color = this.color(i);
             var stroke = Colors.darkenColor(color);
             return (
                 <g key={"lines" + i}>


### PR DESCRIPTION
Since the `cyclic` function already handles cycling through the available colors whether or not a custom pallete is supplied, there's no reason to hardcode a limit of 3 colors on top of that.